### PR TITLE
Fix storage_test suite

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -3,9 +3,12 @@
 package storageconsul
 
 import (
-	"github.com/caddyserver/certmagic"
 	consul "github.com/hashicorp/consul/api"
+	"context"
+	"errors"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"io/fs"
 	"os"
 	"path"
 	"testing"
@@ -17,117 +20,120 @@ var consulClient *consul.Client
 const TestPrefix = "consultlstest"
 
 // these tests needs a running Consul server
-func setupConsulEnv(t *testing.T) *ConsulStorage {
+func setupConsulEnv(t *testing.T) (*ConsulStorage, context.Context) {
 
-	os.Setenv(EnvNamePrefix, TestPrefix)
 	os.Setenv(consul.HTTPTokenEnvName, "2f9e03f8-714b-5e4d-65ea-c983d6b172c4")
 
-	cs, err := New()
+	cs := New()
+	cs.createConsulClient()
+	cs.Prefix = TestPrefix
+	cs.logger = zap.NewExample().Sugar()
+
+	_, err := cs.ConsulClient.KV().DeleteTree(TestPrefix, nil)
 	assert.NoError(t, err)
 
-	_, err = cs.ConsulClient.KV().DeleteTree(TestPrefix, nil)
-	assert.NoError(t, err)
-	return cs
+	ctx := context.Background()
+
+	return cs, ctx
 }
 
 func TestConsulStorage_Store(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
-	err := cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt data"))
+	err := cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt data"))
 	assert.NoError(t, err)
 }
 
 func TestConsulStorage_Exists(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
 	key := path.Join("acme", "example.com", "sites", "example.com", "example.com.crt")
 
-	err := cs.Store(key, []byte("crt data"))
+	err := cs.Store(ctx, key, []byte("crt data"))
 	assert.NoError(t, err)
 
-	exists := cs.Exists(key)
+	exists := cs.Exists(ctx, key)
 	assert.True(t, exists)
 }
 
 func TestConsulStorage_Load(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
 	key := path.Join("acme", "example.com", "sites", "example.com", "example.com.crt")
 	content := []byte("crt data")
 
-	err := cs.Store(key, content)
+	err := cs.Store(ctx, key, content)
 	assert.NoError(t, err)
 
-	contentLoded, err := cs.Load(key)
+	contentLoded, err := cs.Load(ctx, key)
 	assert.NoError(t, err)
 
 	assert.Equal(t, content, contentLoded)
 }
 
 func TestConsulStorage_Delete(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
 	key := path.Join("acme", "example.com", "sites", "example.com", "example.com.crt")
 	content := []byte("crt data")
 
-	err := cs.Store(key, content)
+	err := cs.Store(ctx, key, content)
 	assert.NoError(t, err)
 
-	err = cs.Delete(key)
+	err = cs.Delete(ctx, key)
 	assert.NoError(t, err)
 
-	exists := cs.Exists(key)
+	exists := cs.Exists(ctx, key)
 	assert.False(t, exists)
 
-	contentLoaded, err := cs.Load(key)
+	contentLoaded, err := cs.Load(ctx, key)
 	assert.Nil(t, contentLoaded)
 
-	_, ok := err.(certmagic.ErrNotExist)
-	assert.True(t, ok)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func TestConsulStorage_Stat(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
 	key := path.Join("acme", "example.com", "sites", "example.com", "example.com.crt")
 	content := []byte("crt data")
 
-	err := cs.Store(key, content)
+	err := cs.Store(ctx, key, content)
 	assert.NoError(t, err)
 
-	info, err := cs.Stat(key)
+	info, err := cs.Stat(ctx, key)
 	assert.NoError(t, err)
 
 	assert.Equal(t, key, info.Key)
 }
 
 func TestConsulStorage_List(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
-	err := cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt"))
+	err := cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt"))
 	assert.NoError(t, err)
-	err = cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.key"), []byte("key"))
+	err = cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.key"), []byte("key"))
 	assert.NoError(t, err)
-	err = cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.json"), []byte("meta"))
+	err = cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.json"), []byte("meta"))
 	assert.NoError(t, err)
 
-	keys, err := cs.List(path.Join("acme", "example.com", "sites", "example.com"), true)
+	keys, err := cs.List(ctx, path.Join("acme", "example.com", "sites", "example.com"), true)
 	assert.NoError(t, err)
 	assert.Len(t, keys, 3)
 	assert.Contains(t, keys, path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"))
 }
 
 func TestConsulStorage_ListNonRecursive(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 
-	err := cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt"))
+	err := cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.crt"), []byte("crt"))
 	assert.NoError(t, err)
-	err = cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.key"), []byte("key"))
+	err = cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.key"), []byte("key"))
 	assert.NoError(t, err)
-	err = cs.Store(path.Join("acme", "example.com", "sites", "example.com", "example.com.json"), []byte("meta"))
+	err = cs.Store(ctx, path.Join("acme", "example.com", "sites", "example.com", "example.com.json"), []byte("meta"))
 	assert.NoError(t, err)
 
-	keys, err := cs.List(path.Join("acme", "example.com", "sites"), false)
+	keys, err := cs.List(ctx, path.Join("acme", "example.com", "sites"), false)
 	assert.NoError(t, err)
 
 	assert.Len(t, keys, 1)
@@ -135,32 +141,32 @@ func TestConsulStorage_ListNonRecursive(t *testing.T) {
 }
 
 func TestConsulStorage_LockUnlock(t *testing.T) {
-	cs := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
 	lockKey := path.Join("acme", "example.com", "sites", "example.com", "lock")
 
-	err := cs.Lock(lockKey)
+	err := cs.Lock(ctx, lockKey)
 	assert.NoError(t, err)
 
-	err = cs.Unlock(lockKey)
+	err = cs.Unlock(ctx, lockKey)
 	assert.NoError(t, err)
 }
 
 func TestConsulStorage_TwoLocks(t *testing.T) {
-	cs := setupConsulEnv(t)
-	cs2 := setupConsulEnv(t)
+	cs, ctx := setupConsulEnv(t)
+	cs2, ctx2 := setupConsulEnv(t)
 	lockKey := path.Join("acme", "example.com", "sites", "example.com", "lock")
 
-	err := cs.Lock(lockKey)
+	err := cs.Lock(ctx, lockKey)
 	assert.NoError(t, err)
 
 	go time.AfterFunc(5*time.Second, func() {
-		err = cs.Unlock(lockKey)
+		err = cs.Unlock(ctx, lockKey)
 		assert.NoError(t, err)
 	})
 
-	err = cs2.Lock(lockKey)
+	err = cs2.Lock(ctx2, lockKey)
 	assert.NoError(t, err)
 
-	err = cs2.Unlock(lockKey)
+	err = cs2.Unlock(ctx2, lockKey)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
- add `ctx` parameter to ConsulStorage function calls which now require it
- Set cs.Prefix properly --- setting the EnvNamePrefix environment variable does not work in the tests because that is only read if the module is be instantiated by Caddy, not during the tests. This not only actually uses the correct prefix, but now the KV cleanup done in `setupConsulEnv` cleans the proper path, so you can run tests multiple times in a row without errors because random K/V entries are left
- Set the logger in `setupConsulEnv`
- Switch from certmagic.ErrNotExist to fs.ErrNotExist --- see https://github.com/caddyserver/certmagic/issues/168